### PR TITLE
Test: Never comment mode with vulnerable dependency

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,4 @@ jobs:
       - name: 'Dependency Review'
         uses: sgmurphy/dependency-review-action@update-pr-comment
         with:
-          comment-summary-in-pr: on-failure
+          comment-summary-in-pr: never

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,16 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: sgmurphy/dependency-review-action@update-pr-comment
+        with:
+          comment-summary-in-pr: on-failure

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "lodash": "4.17.19"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "eslint": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "lodash": "4.17.21"
+    "lodash": "4.17.19"
   },
   "devDependencies": {
     "eslint": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fictional-garbanzo",
+  "version": "1.0.0",
+  "description": "Demo repository for dependency review action testing",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "lodash": "4.17.19"
+  },
+  "devDependencies": {
+    "eslint": "^8.0.0"
+  },
+  "keywords": ["demo", "dependency-review"],
+  "author": "Demo",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
This PR tests the `comment-summary-in-pr: never` mode to ensure no comments are added to the PR even when vulnerabilities are found.

## Changes
- Changed workflow to use `comment-summary-in-pr: never`
- Added vulnerable lodash version (4.17.19) that should trigger dependency review failures
- Workflow should run but NOT create any PR comments

## Expected behavior
- Dependency review workflow runs and detects vulnerabilities
- Workflow fails due to vulnerabilities found
- **NO PR comments should be created** (testing never mode)

🤖 Generated with [Claude Code](https://claude.ai/code)